### PR TITLE
[codex] Add best GPTs writing guide pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ GPTsHunter is the first and largest GPTs directory.
 
 New UI is coming soon!
 
+## Content pilots
+
+* [Best GPTs for Writing](docs/best-gpts-for-writing.md) - task-oriented guide based on the highest-priority research recommendation from P117008.
+
 <a target="_blank" href="https://forms.gle/9KgGyjVgKk8WcuU96">Apply to our search API →</a>  
 
 

--- a/docs/best-gpts-for-writing.md
+++ b/docs/best-gpts-for-writing.md
@@ -1,0 +1,156 @@
+# Best GPTs for Writing
+
+Status: content pilot for the task-oriented "Best GPT for X" landing page recommendation from Bio task P117008.
+
+This guide turns the existing writing category into a more decision-oriented page. The goal is to help visitors pick a GPT by writing job instead of scanning a raw popularity list.
+
+## Page Intent
+
+- Primary query: best GPTs for writing
+- Secondary queries: best GPT for copywriting, best GPT for grammar checking, best GPT for resume writing, best GPT for creative writing, best GPT for SEO articles
+- Target user: someone who knows they need a writing assistant but does not know which GPT to try first
+- Conversion path: choose a writing task, open the matching GPTsHunter category/listing, then try or compare a short list
+
+## Hero Copy
+
+# Best GPTs for Writing
+
+Find writing GPTs by job: draft faster, rewrite cleaner, polish grammar, improve resumes, write ads, plan articles, or explore fiction.
+
+GPTsHunter tracks 72,000+ writing GPTs. This guide narrows the category into practical writing workflows so you can start with the GPTs most likely to match your task.
+
+Primary CTA: Browse all writing GPTs
+
+Secondary CTA: Submit a writing GPT
+
+## Selection Rules
+
+Use these rules before calling any GPT a recommended pick:
+
+1. It must have a clear writing job in the title or description.
+2. It should have enough usage or review signal to reduce cold-start risk.
+3. It should map to one primary task, not a vague "does everything" claim.
+4. It should avoid unsupported promises around plagiarism, AI detection bypass, legal advice, medical advice, or guaranteed outcomes.
+5. If the GPT belongs to a sensitive workflow, the page should include a visible limitation note.
+
+## Recommended Sections
+
+### General Drafting and Rewriting
+
+For everyday writing, emails, paragraphs, outlines, and first drafts.
+
+Seed candidates from the current writing category:
+
+- Write For Me
+- Writing Assistant
+- Automated Writer
+- Email and Mail Writer
+
+Decision note: pick these when the user wants broad drafting help and does not need a specialized resume, legal, academic, or SEO workflow.
+
+### Copywriting and Marketing
+
+For ads, landing pages, hooks, product descriptions, and campaign ideas.
+
+Seed candidates from the current writing category:
+
+- Copywriter GPT - Marketing, Branding, Ads
+
+Decision note: separate copywriting GPTs from general writing GPTs because marketers usually care about tone, conversion, and channel constraints.
+
+### Grammar, Clarity, and Editing
+
+For polishing text that already exists.
+
+Seed candidates from the current writing category:
+
+- Grammar Checker
+- Writing Assistant
+
+Decision note: position these as review and revision tools, not original-content tools.
+
+### Resume, CV, and Career Writing
+
+For resumes, cover letters, LinkedIn profiles, and job applications.
+
+Seed candidates from the current writing category:
+
+- CV/Resume writer
+- Resume/CV, Resume & LinkedIn Profile Upgrade
+- Cover Letter
+
+Decision note: include a reminder that users should verify factual claims and tailor final applications themselves.
+
+### Long-Form and SEO Writing
+
+For outlines, blog posts, FAQs, and article drafts.
+
+Seed candidates from the current writing category:
+
+- Fully SEO Optimized Article including FAQ's
+- Article Writer GPT Humanized | Plagiarism Free | SEO Optimized
+- FREE SEO Blog Content Outline Creator & Generator
+
+Decision note: keep quality guidance prominent. A high-output SEO GPT still needs human review for originality, expertise, and factual accuracy.
+
+### Creative Writing and Fiction
+
+For stories, novels, lyrics, role-play, and idea generation.
+
+Seed candidates from the current writing category:
+
+- Unbound Limitless Story Writer
+- Novel Writer
+
+Decision note: creative writing users often need style control, continuity, and feedback more than a generic blank-page generator.
+
+### Academic and Research Writing
+
+For essays, summaries, research assistance, and academic tone.
+
+Seed candidates from the current writing category:
+
+- Academic Assistant Pro
+- Essay Writer & Humanizer
+
+Decision note: include an academic integrity note and avoid framing these as a way to submit unreviewed or undisclosed AI-written work.
+
+## Comparison Table Draft
+
+| Writing job | Good fit when | Start with |
+| --- | --- | --- |
+| First drafts | You need a fast rough draft or email | Write For Me, Writing Assistant |
+| Marketing copy | You need ads, hooks, or campaign copy | Copywriter GPT - Marketing, Branding, Ads |
+| Editing | You already have text and need cleanup | Grammar Checker, Writing Assistant |
+| Job search | You need resume, CV, or cover letter help | CV/Resume writer, Cover Letter |
+| SEO articles | You need outlines, FAQs, or article structure | Fully SEO Optimized Article including FAQ's |
+| Fiction | You need plot, scenes, or story feedback | Unbound Limitless Story Writer, Novel Writer |
+| Academic | You need research or academic style support | Academic Assistant Pro, Essay Writer & Humanizer |
+
+## FAQ Draft
+
+### What is the best GPT for writing?
+
+The best writing GPT depends on the job. For a general draft, start with a broad writing assistant. For a resume, cover letter, ad, article, or fiction project, choose a GPT built for that specific workflow.
+
+### Are writing GPTs good enough to publish directly?
+
+Usually not without review. Use writing GPTs to draft, structure, rewrite, and polish, then check facts, tone, originality, and context before publishing.
+
+### Which GPT should I use for resume writing?
+
+Start with a resume or cover-letter specific GPT, then manually verify dates, employers, titles, achievements, and role-specific keywords.
+
+### Which GPT should I use for SEO articles?
+
+Use an SEO article GPT for outlines, headings, FAQs, and draft structure. Do not rely on it as the final source of expertise or factual accuracy.
+
+## Source Pages
+
+- GPTsHunter writing category: https://www.gptshunter.com/gpt-store-categories/writing
+- Source research task: P117008
+
+## Verification Notes
+
+- Source category checked on 2026-07-02.
+- This is a static content pilot only. It does not add routing, templates, comparison UI, schema markup, or production deployment wiring.

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@ GPTsHunter crawls and categorizes custom GPTs built on OpenAI's platform. Each G
 - [Home](https://www.gptshunter.com/): Main directory page with featured and trending GPTs
 - [GPT Store Categories](https://www.gptshunter.com/gpt-store-categories): Browse GPTs by category (programming, writing, education, etc.)
 - [Blog](https://www.gptshunter.com/blog): Articles about GPTs, the GPT Store, and AI tools
+- [Best GPTs for Writing content pilot](https://github.com/airyland/gptshunter.com/blob/master/docs/best-gpts-for-writing.md): Task-oriented writing GPT guide draft for selecting GPTs by job instead of scanning a raw category list
 
 ## GPT Listings
 
@@ -24,6 +25,10 @@ GPTsHunter crawls and categorizes custom GPTs built on OpenAI's platform. Each G
 ## Blog
 
 - Articles about GPTs, the GPT Store, and AI tools (see /blog for current posts)
+
+## Task-Oriented Guides
+
+- [Best GPTs for Writing](https://github.com/airyland/gptshunter.com/blob/master/docs/best-gpts-for-writing.md): A pilot guide that groups writing GPTs by use case, including drafting, copywriting, editing, resumes, SEO articles, fiction, and academic writing.
 
 ## Optional
 


### PR DESCRIPTION
## Summary

- Adds `docs/best-gpts-for-writing.md`, a task-oriented content pilot for selecting writing GPTs by job instead of scanning a raw category list.
- Links the guide from `README.md` and `llms.txt` so humans and LLM crawlers can discover the pilot.

## Source Research Task

- Source: P117008, `调研 X/Reddit 上 gptshunter.com 相关方向的痛点和低竞争场景`.
- Selected recommendation: Direction A / highest-priority task, build "Best GPT for X" task-oriented curation pages.
- Why this scope: the current checkout only contains static repo content (`README.md` and `llms.txt`), so this lands the smallest verifiable content pilot without inventing runtime app code.

## Verification

- Read local Bio task context and comments for this execution task.
- Fetched P117008 task detail, comments, and all agent-run outputs through the Bio API.
- Checked GPTsHunter writing category in browser on 2026-07-02: https://www.gptshunter.com/gpt-store-categories/writing
- Ran `git diff --check`.
- Ran focused file-presence checks for `README.md`, `llms.txt`, and `docs/best-gpts-for-writing.md`.

## Not In Scope

- No production route/template wiring.
- No comparison component or schema markup.
- No deployment changes.
- No database, crawler, or production data changes.